### PR TITLE
docs: add contributing guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,47 @@
+# Contributing to MetaGPT
+
+Thank you for your interest in improving MetaGPT! This guide will help you get set up for development, run code quality checks, and execute the test suite.
+
+## Setup
+
+1. Fork the repository and clone your fork:
+   ```bash
+   git clone https://github.com/<your-username>/MetaGPT.git
+   cd MetaGPT
+   ```
+2. Create and activate a Python 3.9+ (but <3.12) virtual environment:
+   ```bash
+   python -m venv .venv
+   source .venv/bin/activate
+   ```
+3. Install dependencies:
+   ```bash
+   pip install -e .
+   ```
+
+## Pre-commit
+
+This project uses [pre-commit](https://pre-commit.com/) for linting and formatting.
+
+1. Install the pre-commit hooks:
+   ```bash
+   pre-commit install
+   ```
+2. Run pre-commit on changed files before committing:
+   ```bash
+   pre-commit run --files <file1> <file2>
+   ```
+   To check the whole project, use `pre-commit run --all-files`.
+
+## Tests
+
+Run the test suite with [pytest](https://pytest.org/):
+
+```bash
+pytest
+```
+
+Please ensure all tests pass before submitting a pull request.
+
+---
+Happy hacking!

--- a/README.md
+++ b/README.md
@@ -132,6 +132,7 @@ https://github.com/user-attachments/assets/888cb169-78c3-4a42-9d62-9d90ed3928c9
   - [MetaGPT Usage & Development Guide | MultiAgent 101](https://docs.deepwisdom.ai/main/en/guide/tutorials/multi_agent_101.html)
   - [Mike's Team Leader workflow](docs/team_leader_di.md)
 - 🧑‍💻 Contribution
+  - [Contributing Guide](CONTRIBUTING.md)
   - [Develop Roadmap](docs/ROADMAP.md)
 - 🔖 Use Cases
   - [Data Interpreter](https://docs.deepwisdom.ai/main/en/guide/use_cases/agent/interpreter/intro.html)


### PR DESCRIPTION
## Summary
- add CONTRIBUTING.md with setup, pre-commit, and test instructions
- link contributing guide from README

## Testing
- `pre-commit run --files README.md CONTRIBUTING.md`
- `pytest` *(fails: Please set your API key in /workspace/MetaGPT/config/config2.yaml)*

------
https://chatgpt.com/codex/tasks/task_e_688e997d28a0832cb2ac5930aa98978a